### PR TITLE
Create landing page for GitHub Pages

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+gas.moukaeritai.work

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Google Apps Script Projects</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <div class="card">
+            <h2>moodle-multichoice-question-validator</h2>
+            <a href="#" class="button">Open Validator</a>
+        </div>
+        <div class="card">
+            <h2>moodle-true-false-quiz-validator</h2>
+            <a href="#" class="button">Open Validator</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,49 @@
+body {
+    font-family: sans-serif;
+    margin: 0;
+    background-color: #f4f4f4;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 20px;
+}
+
+.card {
+    background-color: white;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    padding: 20px;
+    width: 300px;
+    text-align: center;
+}
+
+.card h2 {
+    margin-top: 0;
+    font-size: 1.5em;
+    color: #333;
+}
+
+.button {
+    display: inline-block;
+    background-color: #007bff;
+    color: white;
+    padding: 10px 20px;
+    text-decoration: none;
+    border-radius: 5px;
+    font-weight: bold;
+    transition: background-color 0.3s ease;
+}
+
+.button:hover {
+    background-color: #0056b3;
+}


### PR DESCRIPTION
This commit introduces the initial setup for GitHub Pages.

- Creates a `docs/` directory.
- Adds a `CNAME` file for `gas.moukaeritai.work`.
- Adds `docs/index.html` with a basic structure for a landing page.
- Adds `docs/style.css` for styling the landing page.
- The landing page includes two cards:
    - moodle-multichoice-question-validator
    - moodle-true-false-quiz-validator
- Each card has a placeholder button "Open Validator".

This will serve as the main entry point for the projects hosted on GitHub Pages.